### PR TITLE
travis: PHP 7.0 nightly added + few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,16 @@ php:
  - 5.4
  - 5.5
  - 5.6
+ - 7.0
  - hhvm
 
-before_install:
- - composer install --dev
+matrix:
+ fast_finish: true
+ allow_failures:
+  - php: 7.0
+
+before_script:
+ - composer install --prefer-source
 
 script:
  - composer test


### PR DESCRIPTION
- `--dev` is by default for almost a year
- `--prefer-source` option is to get recent versions of dependencies, see https://getcomposer.org/doc/03-cli.md#install
