### PR TITLE
Monad IO utility functions like: until, getChar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
     },
     "files": [
       "src/Functional/functions.php",
+      "src/Functional/predicates.php",
+      "src/Functional/strings.php",
       "src/Monad/Either/functions.php",
       "src/Monad/Maybe/functions.php",
       "src/Monad/IO/functions.php",

--- a/src/Functional/predicates.php
+++ b/src/Functional/predicates.php
@@ -1,0 +1,36 @@
+<?php
+namespace Functional;
+
+const eql = 'Functional\eql';
+
+/**
+ * eql :: a -> a -> Bool
+ *
+ * @param mixed $expected
+ * @param mixed $value
+ * @return mixed
+ */
+function eql($expected, $value = null)
+{
+    return call_user_func_array(curryN(2, function ($expected, $value) {
+        return $expected === $value;
+    }), func_get_args());
+}
+
+
+const orr = 'Functional\orr';
+
+/**
+ * orr :: (a -> Bool) -> (a -> Bool) -> a -> Bool
+ *
+ * @param callable $predicateA
+ * @param callable|null $predicateB
+ * @param mixed $value
+ * @return mixed
+ */
+function orr(callable $predicateA, callable $predicateB = null, $value = null)
+{
+    return call_user_func_array(curryN(3, function (callable $a, callable $b, $value) {
+        return call_user_func($a, $value) || call_user_func($b, $value);
+    }), func_get_args());
+}

--- a/src/Functional/strings.php
+++ b/src/Functional/strings.php
@@ -1,0 +1,18 @@
+<?php
+namespace Functional;
+
+const concatStrings = 'Functional\concatStrings';
+
+/**
+ * concatStrings :: String -> String -> String
+ *
+ * @param string $a
+ * @param string $b
+ * @return string
+ */
+function concatStrings($a, $b = null)
+{
+    return call_user_func_array(curryN(2, function ($a, $b) {
+        return $a . $b;
+    }), func_get_args());
+}


### PR DESCRIPTION
- Redefines how IO\getLine works (now use getChar function)
- Introduce utility functions like f\eql, f\orr
- Thanks to them is possible to read from STDIN stream i.e:

``` php
require_once 'vendor/autoload.php';

use Functional as f;
use Monad\IO as IO;

$result = IO\until(f\orr(f\eql(PHP_EOL), f\eql(false)), function ($value, $accumulator) {
    return $value;
}, null, IO\getChar());

var_dump($result->run());
```

run:

```
echo "asd" | php xpath.php 
// string("d")
```
