### PR TITLE
Fix travis build on HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: php
 
+dist: trusty
+
 php:
  - 5.6
  - 7.0
  - 7.1
- - hhvm
+ - hhvm-3.12
 
 matrix:
  allow_failures:
-  - php: hhvm
+  - php: hhvm-3.12
 
 before_script:
  - composer self-update


### PR DESCRIPTION
Travis build fails because no HHVM version is specified, travis then tries
to build on a pretty old 3.3 version. Unfortunately, php-cs-fixer conflicts
with HHVM prior to version 3.9.

In this PR, we force an Ubuntu trusty in order to be able to choose a more
recent HHVM version, and set it to 3.12.

see https://docs.travis-ci.com/user/languages/php/#HHVM-versions for further details