### PR TITLE
Implement `Listt::head` and `Listt::tail`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
   "require-dev": {
     "phpunit/phpunit": "^4.7",
     "friendsofphp/php-cs-fixer": "^2",
-    "codeclimate/php-test-reporter": "^0.4.4"
+    "codeclimate/php-test-reporter": "^0.4.4",
+    "giorgiosironi/eris": "^0.9"
   },
   "license": "MIT",
   "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "11bacaf078cb372c95433d25c250ac3f",
+    "content-hash": "b636d4274f160b6b879ca957312bb86b",
     "packages": [],
     "packages-dev": [
         {
@@ -433,6 +433,61 @@
                 "phpunit"
             ],
             "time": "2017-08-23T07:46:41+00:00"
+        },
+        {
+            "name": "giorgiosironi/eris",
+            "version": "0.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giorgiosironi/eris.git",
+                "reference": "538bbdaeb5679d094a33864fd54f85d6a4ffaa74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giorgiosironi/eris/zipball/538bbdaeb5679d094a33864fd54f85d6a4ffaa74",
+                "reference": "538bbdaeb5679d094a33864fd54f85d6a4ffaa74",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpunit/phpunit": ">4,<7"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "^1.11.2",
+                "icomefromthenet/reverse-regex": "v0.0.6.3"
+            },
+            "suggest": {
+                "icomefromthenet/reverse-regex": "v0.0.6.3 for the regex() Generator"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Eris\\": "src/"
+                },
+                "files": [
+                    "src/Generator/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gabriele Lana",
+                    "email": "gabriele.lana@gmail.com"
+                },
+                {
+                    "name": "Giorgio Sironi",
+                    "email": "info@giorgiosironi.com"
+                },
+                {
+                    "name": "Mirko Bonadei",
+                    "email": "mirko.bonadei@gmail.com"
+                }
+            ],
+            "description": "PHP library for property-based testing. Integrates with PHPUnit.",
+            "time": "2017-03-12T17:39:53+00:00"
         },
         {
             "name": "guzzle/guzzle",

--- a/src/Functional/functions.php
+++ b/src/Functional/functions.php
@@ -580,7 +580,7 @@ const isNativeTraversable = 'Widmogrod\Functional\isNativeTraversable';
  */
 function isNativeTraversable($value)
 {
-    return is_array($value) || $value instanceof \Traversable;
+    return \is_iterable($value);
 }
 
 /**

--- a/src/Primitive/Listt.php
+++ b/src/Primitive/Listt.php
@@ -172,12 +172,14 @@ class Listt implements
      *
      * @throws \BadMethodCallException
      */
-    public function tail(): Listt
+    public function tail(): self
     {
         ($generator = $this->guardEmptyGenerator('tail of empty Listt'))->next();
 
         return $generator->valid()
-            ? self::of((function ($values) { yield from $values; })($generator))
+            ? self::of((function ($values) {
+                yield from $values;
+            })($generator))
             : self::mempty();
     }
 

--- a/test/Primitive/ListtTest.php
+++ b/test/Primitive/ListtTest.php
@@ -2,6 +2,7 @@
 
 namespace test\Monad;
 
+use Eris\TestTrait;
 use Widmogrod\FantasyLand\Applicative;
 use Widmogrod\FantasyLand\Functor;
 use Widmogrod\FantasyLand\Monoid;
@@ -11,9 +12,13 @@ use Widmogrod\Helpful\FunctorLaws;
 use Widmogrod\Helpful\MonadLaws;
 use Widmogrod\Helpful\MonoidLaws;
 use Widmogrod\Primitive\Listt;
+use function Eris\Generator\choose;
+use function Eris\Generator\vector;
 
 class ListtTest extends \PHPUnit_Framework_TestCase
 {
+    use TestTrait;
+
     /**
      * @dataProvider provideData
      */
@@ -148,5 +153,59 @@ class ListtTest extends \PHPUnit_Framework_TestCase
                 $this->randomize(),
             ];
         }, array_fill(0, 50, null));
+    }
+
+    public function test_head_on_empty_list_is_undefined()
+    {
+        $this->setExpectedException(\BadMethodCallException::class, 'head of empty Listt');
+
+        Listt::mempty()->head();
+    }
+
+    public function test_head_extracts_first_element()
+    {
+        $this->forAll(
+            vector(10, choose(1, 1000))
+        )(
+            function ($sequence) {
+                $list = Listt::of($sequence);
+                $current = current($sequence);
+
+                $this->assertSame($current, $list->head());
+                $this->assertSame($current, $list->head());
+            }
+        );
+    }
+
+    public function test_tail_on_empty_list()
+    {
+        $this->setExpectedException(\BadMethodCallException::class, 'tail of empty Listt');
+
+        Listt::mempty()->tail();
+    }
+
+    public function test_tail_with_single_element_Listt()
+    {
+        $this->forAll(
+            vector(1, choose(1, 1000))
+        )(
+            function ($sequence) {
+                $this->assertTrue(Listt::of($sequence)->tail()->equals(Listt::mempty()));
+            }
+        );
+    }
+
+    public function test_tail_with_multiple_element_Listt()
+    {
+        $this->forAll(
+            vector(10, choose(1, 1000))
+        )(
+            function ($sequence) {
+                $list = Listt::of($sequence);
+                array_shift($sequence);
+
+                $this->assertEquals($sequence, $list->tail()->extract());
+            }
+        );
     }
 }


### PR DESCRIPTION
This is a first draft on continuation for https://github.com/widmogrod/php-functional/issues/46

Also added [**Eris**](http://eris.readthedocs.io/en/latest/index.html) randomized property test extension (QuickCheck port).

Implementation uses generators to treat all `iterable` the same way.