### PR TITLE
Curry function doesn't work well with all callable forms

### DIFF
--- a/src/Functional/functions.php
+++ b/src/Functional/functions.php
@@ -83,7 +83,7 @@ function curryN($numberOfArguments, callable $function, array $args = [])
  */
 function curry(callable $function, array $args = [])
 {
-    $reflectionOfFunction = new \ReflectionFunction($function);
+    $reflectionOfFunction = new \ReflectionFunction(\Closure::fromCallable($function));
 
     $numberOfArguments = count($reflectionOfFunction->getParameters());
     // We cant expect more arguments than are defined in function

--- a/test/Functional/CurryTest.php
+++ b/test/Functional/CurryTest.php
@@ -105,4 +105,78 @@ class CurryTest extends \PHPUnit\Framework\TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider provideCallablesToTest
+     */
+    public function test_it_curry_every_type_of_callable(callable $callable)
+    {
+        $curried = f\curry($callable);
+
+        $this->assertInstanceOf(\Closure::class, $curried);
+        $this->assertInstanceOf(\Closure::class, $curried(1));
+        $this->assertSame([1, 2], $curried(1)(2));
+    }
+
+    public function provideCallablesToTest()
+    {
+        return [
+            'closure' => [
+                function ($a, $b) {
+                    return [$a, $b];
+                }
+            ],
+            'named function' => [
+                'test\Functional\inner\my_named_function'
+            ],
+            'static method and static context' => [
+                [inner\MyClass::class, 'myStaticMethod']
+            ],
+            'static method and object context' => [
+                [new inner\MyClass(), 'myStaticMethod']
+            ],
+            'method and object context' => [
+                [new inner\MyClass(), 'myMethod']
+            ],
+            'static method as string' => [
+                'test\Functional\inner\MyClass::myStaticMethod'
+            ],
+            'invokable object' => [
+                new inner\InvokableClass()
+            ]
+        ];
+    }
+
+    public static function staticMethod($a, $b)
+    {
+        return [$a, $b];
+    }
+}
+
+namespace  test\Functional\inner;
+
+function my_named_function($a, $b)
+{
+    return [$a, $b];
+}
+
+class MyClass
+{
+    public function myMethod($a, $b)
+    {
+        return [$a, $b];
+    }
+
+    public static function myStaticMethod($a, $b)
+    {
+        return [$a, $b];
+    }
+}
+
+class InvokableClass
+{
+    public function __invoke($a, $b)
+    {
+        return [$a, $b];
+    }
 }


### PR DESCRIPTION
The `curry` function fails when the first argument is not a callable in a string form.

I'm going to add two commits:

1. The first one adds a test which proves what I'm saying
2. The second one is a proposal for a fix