### PR TITLE
Fix all return typehints in php doc

### DIFF
--- a/src/Functional/functions.php
+++ b/src/Functional/functions.php
@@ -280,7 +280,7 @@ const filter = 'Widmogrod\Functional\filter';
  * @param callable $predicate
  * @param Foldable $list
  *
- * @return Foldable
+ * @return Foldable|\Closure
  */
 function filter(callable $predicate, Foldable $list = null)
 {
@@ -497,7 +497,7 @@ const sequenceM = 'Widmogrod\Functional\sequenceM';
  * @param Monad $a
  * @param Monad $b
  *
- * @return Monad
+ * @return Monad|\Closure
  */
 function sequenceM(Monad $a, Monad $b = null): Monad
 {
@@ -525,7 +525,7 @@ const traverse = 'Widmogrod\Functional\traverse';
  * @param callable    $transformation (a -> f b)
  * @param Traversable $t              t a
  *
- * @return Applicative f (t b)
+ * @return \Closure|Applicative f (t b)
  */
 function traverse(callable $transformation, Traversable $t = null)
 {
@@ -548,7 +548,7 @@ function traverse(callable $transformation, Traversable $t = null)
  * @param callable $f  (a -> m Bool)
  * @param Foldable $xs [a]
  *
- * @return Monad m [a]
+ * @return \Closure|Monad m [a]
  */
 function filterM(callable $f, Foldable $xs = null)
 {

--- a/src/Functional/infinit.php
+++ b/src/Functional/infinit.php
@@ -22,9 +22,9 @@ const iterate = 'Widmogrod\Functional\iterate';
  * ```haskell
  * iterate f x == [x, f x, f (f x), ...]
  * ```
- * @param  callable $fn
- * @param  mixed    $a
- * @return Listt
+ * @param  callable       $fn
+ * @param  mixed          $a
+ * @return Listt|\Closure
  */
 function iterate(callable $fn, $a = null)
 {
@@ -46,7 +46,7 @@ const repeat = 'Widmogrod\Functional\repeat';
  * repeat x is an infinite list, with x the value of every element.
  *
  * @param $a
- * @return mixed|ListtCons
+ * @return ListtCons
  */
 function repeat($a)
 {
@@ -66,9 +66,9 @@ const replicate = 'Widmogrod\Functional\replicate';
  * replicate n x is a list of length n with x the value of every element.
  * It is an instance of the more general genericReplicate, in which n may be of any integral type.
  *
- * @param  int   $n
- * @param  mixed $a
- * @return Listt
+ * @param  int            $n
+ * @param  mixed          $a
+ * @return Listt|\Closure
  */
 function replicate(int $n, $a = null): Listt
 {

--- a/src/Functional/listt.php
+++ b/src/Functional/listt.php
@@ -128,9 +128,9 @@ const prepend = 'Widmogrod\Functional\prepend';
 /**
  * prepend :: a -> [a] -> [a]
  *
- * @param  mixed $x
- * @param  Listt $xs
- * @return Listt
+ * @param  mixed          $x
+ * @param  Listt          $xs
+ * @return Listt|\Closure
  */
 function prepend($x, Listt $xs = null)
 {

--- a/src/Functional/monoid.php
+++ b/src/Functional/monoid.php
@@ -26,12 +26,12 @@ const concatM = 'Widmogrod\Functional\concatM';
 /**
  * concatM :: a -> a -> a
  *
- * @param Semigroup $a
- * @param Semigroup $b
+ * @param Semigroup      $a
+ * @param Semigroup|null $b
  *
- * @return Semigroup
+ * @return Semigroup|\Closure
  */
-function concatM(Semigroup $a, Semigroup $b)
+function concatM(Semigroup $a, Semigroup $b = null)
 {
     return curryN(2, function (Semigroup $a, Semigroup $b) {
         return $a->concat($b);

--- a/src/Functional/predicates.php
+++ b/src/Functional/predicates.php
@@ -12,11 +12,11 @@ const eql = 'Widmogrod\Functional\eql';
  * @param mixed $expected
  * @param mixed $value
  *
- * @return mixed
+ * @return bool|\Closure
  */
 function eql($expected, $value = null)
 {
-    return curryN(2, function ($expected, $value) {
+    return curryN(2, function ($expected, $value): bool {
         return $expected === $value;
     })(...func_get_args());
 }
@@ -29,11 +29,11 @@ const lt = 'Widmogrod\Functional\lt';
  * @param mixed $expected
  * @param mixed $value
  *
- * @return mixed
+ * @return bool|\Closure
  */
 function lt($expected, $value = null)
 {
-    return curryN(2, function ($expected, $value) {
+    return curryN(2, function ($expected, $value): bool {
         return $value < $expected;
     })(...func_get_args());
 }
@@ -48,11 +48,11 @@ const orr = 'Widmogrod\Functional\orr';
  * @param callable|null $predicateB
  * @param mixed         $value
  *
- * @return mixed
+ * @return bool|\Closure
  */
 function orr(callable $predicateA, callable $predicateB = null, $value = null)
 {
-    return curryN(3, function (callable $a, callable $b, $value) {
+    return curryN(3, function (callable $a, callable $b, $value): bool {
         return $a($value) || $b($value);
     })(...func_get_args());
 }

--- a/src/Functional/setoid.php
+++ b/src/Functional/setoid.php
@@ -14,7 +14,7 @@ const equal = 'Widmogrod\Functional\equal';
  * @param Setoid $a
  * @param Setoid $b
  *
- * @return bool
+ * @return bool|\Closure
  */
 function equal(Setoid $a, Setoid $b = null)
 {

--- a/src/Functional/strings.php
+++ b/src/Functional/strings.php
@@ -9,10 +9,10 @@ const concatStrings = 'Widmogrod\Functional\concatStrings';
 /**
  * concatStrings :: String -> String -> String
  *
- * @param string $a
- * @param string $b
+ * @param string      $a
+ * @param string|null $b
  *
- * @return string
+ * @return string|\Closure
  */
 function concatStrings($a, $b = null)
 {

--- a/src/Functional/sublist.php
+++ b/src/Functional/sublist.php
@@ -19,9 +19,9 @@ const take = 'Widmogrod\Functional\take';
  *
  * take n, applied to a list xs, returns the prefix of xs of length n, or xs itself if n > length xs:
  *
- * @param  int   $n
- * @param  Listt $xs
- * @return Listt
+ * @param  int            $n
+ * @param  Listt          $xs
+ * @return Listt|\Closure
  */
 function take(int $n, Listt $xs = null)
 {
@@ -45,9 +45,9 @@ const drop = 'Widmogrod\Functional\drop';
  * drop :: Int -> [a] -> [a]
  *
  * drop n xs returns the suffix of xs after the first n elements, or [] if n > length xs:
- * @param  int   $n
- * @param  Listt $xs
- * @return Listt
+ * @param  int            $n
+ * @param  Listt          $xs
+ * @return Listt|\Closure
  */
 function drop(int $n, Listt $xs = null)
 {
@@ -80,9 +80,9 @@ const dropWhile = 'Widmogrod\Functional\dropWhile';
  *  | otherwise =  xs
  * ```
  *
- * @param  callable $predicate
- * @param  Listt    $xs
- * @return Listt
+ * @param  callable       $predicate
+ * @param  Listt          $xs
+ * @return Listt|\Closure
  */
 function dropWhile(callable $predicate, Listt $xs = null)
 {
@@ -122,9 +122,9 @@ const span = 'Widmogrod\Functional\span';
  * where first element is longest prefix (possibly empty) of xs of elements
  * that satisfy p and second element is the remainder of the list
  *
- * @param  callable $predicate
- * @param  Listt    $xs
- * @return array
+ * @param  callable       $predicate
+ * @param  Listt          $xs
+ * @return array|\Closure
  */
 function span(callable $predicate, Listt $xs = null)
 {

--- a/src/Functional/zipping.php
+++ b/src/Functional/zipping.php
@@ -19,9 +19,9 @@ const zip = 'Widmogrod\Functional\zip';
  * zip takes two lists and returns a list of corresponding pairs. If one input list is short, excess elements of the longer list are discarded.
  * zip is right-lazy:
  *
- * @param  Listt      $xs
- * @param  Listt|null $ys
- * @return Listt
+ * @param  Listt          $xs
+ * @param  Listt|null     $ys
+ * @return Listt|\Closure
  */
 function zip(Listt $xs, Listt $ys = null)
 {

--- a/src/Monad/Either/functions.php
+++ b/src/Monad/Either/functions.php
@@ -80,7 +80,7 @@ const doubleMap = 'Widmogrod\Monad\Either\doubleMap';
  * @param callable $right
  * @param Either   $either
  *
- * @return Left|Right
+ * @return Left|Right|\Closure
  */
 function doubleMap(callable $left, callable $right = null, Either $either = null)
 {

--- a/src/Monad/IO/errors.php
+++ b/src/Monad/IO/errors.php
@@ -48,7 +48,7 @@ const tryCatch = 'Widmogrod\Monad\IO\tryCatch';
  * @param M\IO     $io
  * @param callable $catchFunction
  *
- * @return M\IO
+ * @return M\IO|\Closure
  */
 function tryCatch(M\IO $io = null, callable $catchFunction = null)
 {


### PR DESCRIPTION
Some functions like `Either\doubleMap` are curried, but their return typehint doesn't include `\Closure` or `callable`.

When using `doubleMap` in a `pipeline` with a smart IDE, the inspector marks this usage as an error, and consequently, the resulting experience is pretty poor.

The aim of this PR is to fix all those type hints in order to improve the usage experience.