### PR TITLE
liftM2 is not working with IO monads

### DIFF
--- a/src/Functional/functions.php
+++ b/src/Functional/functions.php
@@ -398,20 +398,10 @@ function liftM2(
     Monad $ma = null,
     Monad $mb = null
 ) {
-    return curryN(
-        3,
-        function (
-            callable $transformation,
-            Monad $ma,
-            Monad $mb
-        ) {
-            return $ma->bind(function ($a) use ($mb, $transformation) {
-                return $mb->map(function ($b) use ($a, $transformation) {
-                    return $transformation($a, $b);
-                });
-            });
-        }
-    )(...func_get_args());
+    return call_user_func_array(
+        liftA2,
+        func_get_args()
+    );
 }
 
 /**

--- a/src/Functional/functions.php
+++ b/src/Functional/functions.php
@@ -405,9 +405,11 @@ function liftM2(
             Monad $ma,
             Monad $mb
         ) {
-            return bindM2(function ($a, $b) use ($transformation, $mb): Monad {
-                return $mb::of($transformation($a, $b));
-            }, $ma, $mb);
+            return $ma->bind(function ($a) use ($mb, $transformation) {
+                return $mb->map(function ($b) use ($a, $transformation) {
+                    return $transformation($a, $b);
+                });
+            });
         }
     )(...func_get_args());
 }

--- a/test/Functional/LiftM2Test.php
+++ b/test/Functional/LiftM2Test.php
@@ -26,7 +26,7 @@ class LiftM2Test extends \PHPUnit\Framework\TestCase
         $mc = f\liftM2($transformation, $ma, $mb);
 
         $this->assertInstanceOf($expectedFQCN, $mc);
-        if($valueAssertion !== null) {
+        if ($valueAssertion !== null) {
             $valueAssertion($mc);
         }
     }


### PR DESCRIPTION
Hi @widmogrod I've noticed that the implementation I proposed in #100 throws a type error with IO monads.

This PR consists in two commits. 
1. the test to highlight the problem
2. the fix

Thanks