### PR TITLE
php8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "widmogrod/php-functional",
   "description": "Functors, Applicative and Monads are fascinating concept. Purpose of this library is to explore them in OOP PHP world.",
   "require": {
-    "php": ">=7.1",
+    "php": "^7.1|^8.0",
     "functional-php/fantasy-land": "^1"
   },
   "require-dev": {

--- a/example/FreeBddStyleDSLTest.php
+++ b/example/FreeBddStyleDSLTest.php
@@ -13,7 +13,7 @@ use function Widmogrod\Functional\curryN;
 use function Widmogrod\Functional\push_;
 use function Widmogrod\Monad\Free\foldFree;
 use function Widmogrod\Monad\Free\liftF;
-use function Widmogrod\Useful\match;
+use function Widmogrod\Useful\matchPatterns;
 
 interface ScenarioF extends Functor
 {
@@ -162,7 +162,7 @@ const interpretScenario = 'example\interpretScenario';
  */
 function interpretScenario(callable $interpretAction, callable $interpretAssertion, ScenarioF $f)
 {
-    return match([
+    return matchPatterns([
         Given::class => function (Given $a): State {
             return State::of(function () use ($a) {
                 return [$a->next, $a->state];

--- a/example/FreeCalculatorTest.php
+++ b/example/FreeCalculatorTest.php
@@ -14,7 +14,7 @@ use function Widmogrod\Functional\compose;
 use function Widmogrod\Functional\bindM2;
 use function Widmogrod\Monad\Free\foldFree;
 use function Widmogrod\Monad\Free\liftF;
-use function Widmogrod\Useful\match;
+use function Widmogrod\Useful\matchPatterns;
 
 /**
  *  Exp a next
@@ -201,7 +201,7 @@ const interpretInt = 'example\interpretInt';
  */
 function interpretInt(ExpF $f)
 {
-    return match([
+    return matchPatterns([
         IntVal::class => function (int $x, callable $next): Identity {
             return Identity::of($x)->map($next);
         },
@@ -227,7 +227,7 @@ const interpretPrint = 'example\interpretPrint';
  */
 function interpretPrint(ExpF $f)
 {
-    return match([
+    return matchPatterns([
         IntVal::class => function (int $x, callable $next): Identity {
             return Identity::of(Stringg::of("$x"))->map($next);
         },
@@ -259,7 +259,7 @@ const optimizeCalc = 'example\optimizeCalc';
  */
 function optimizeCalc(ExpF $f)
 {
-    return match([
+    return matchPatterns([
         IntVal::class => function ($x, callable $next) {
             return new IntVal($x, $next);
         },

--- a/example/FreeMonadTest.php
+++ b/example/FreeMonadTest.php
@@ -14,7 +14,7 @@ use Widmogrod\Primitive\Listt;
 use const Widmogrod\Monad\IO\pure;
 use const Widmogrod\Monad\State\value;
 use function Widmogrod\Functional\fromNil;
-use function Widmogrod\Useful\match;
+use function Widmogrod\Useful\matchPatterns;
 
 interface TeletypeF extends Functor
 {
@@ -106,7 +106,7 @@ const interpretIO = 'example2\interpretIO';
 // run :: TeletypeF -> IO ()
 function interpretIO(TeletypeF $r)
 {
-    return match([
+    return matchPatterns([
         PutStrLn::class => function (PutStrLn $a) {
             return IO\putStrLn($a->str)->map(function () use ($a) {
                 return $a->next;
@@ -126,7 +126,7 @@ const interpretState = 'example2\interpretState';
 // runTest :: TeletypeF -> State MonadFree []
 function interpretState(TeletypeF $r)
 {
-    return match([
+    return matchPatterns([
         PutStrLn::class => function (PutStrLn $a) {
             return State::of(function (Listt $state) use ($a) {
                 return [

--- a/example/FreeUnionTypeGeneratorTest.php
+++ b/example/FreeUnionTypeGeneratorTest.php
@@ -18,7 +18,7 @@ use function Widmogrod\Functional\prepend;
 use function Widmogrod\Functional\reduce;
 use function Widmogrod\Monad\Free\foldFree;
 use function Widmogrod\Monad\Free\liftF;
-use function Widmogrod\Useful\match;
+use function Widmogrod\Useful\matchPatterns;
 
 /**
  * type UnionF _ next
@@ -263,7 +263,7 @@ const interpretTypesAndGenerate = 'example\interpretTypesAndGenerate';
  */
 function interpretTypesAndGenerate(UnionF $f): Identity
 {
-    return match([
+    return matchPatterns([
         Declare_::class => function (string $name, array $args, callable $next): Identity {
             $a = new GeneratorLazy();
             $a->declaration = [
@@ -293,7 +293,7 @@ class FreeUnionTypeGeneratorTest extends \PHPUnit\Framework\TestCase
     {
         // $interpret :: UnionF -> Identity Free a
         $interpret = function (UnionF $f): Identity {
-            return match([
+            return matchPatterns([
                 Declare_::class => function (string $name, array $args, callable $next): Identity {
                     return Identity::of([
                         'interface' => $name,

--- a/src/Monad/Control/Doo/interpretation.php
+++ b/src/Monad/Control/Doo/interpretation.php
@@ -15,7 +15,7 @@ use const Widmogrod\Monad\Reader\pure;
 use function Widmogrod\Functional\sequenceM;
 use function Widmogrod\Monad\Free\foldFree;
 use function Widmogrod\Monad\Reader\runReader;
-use function Widmogrod\Useful\match;
+use function Widmogrod\Useful\matchPatterns;
 
 /**
  * @var callable
@@ -32,7 +32,7 @@ const interpretation = 'Widmogrod\Monad\Control\Doo\interpretation';
  */
 function interpretation(DooF $f)
 {
-    return match([
+    return matchPatterns([
         Let::class => function (string $name, Monad $m, MonadFree $next): Reader {
             return Reader::of(function (Registry $registry) use ($name, $m, $next) {
                 return $m->bind(function ($v) use ($name, $next, $registry) {

--- a/src/Useful/match.php
+++ b/src/Useful/match.php
@@ -26,7 +26,7 @@ const any = 'Widmogrod\Useful\PatternAny';
  *
  * @return mixed
  */
-function match(array $patterns, $value = null)
+function matchPatterns(array $patterns, $value = null)
 {
     return curryN(2, function (array $patterns, $value) {
         if (count($patterns) === 0) {

--- a/test/Useful/MatchTest.php
+++ b/test/Useful/MatchTest.php
@@ -6,7 +6,7 @@ namespace test\Useful;
 
 use Widmogrod\Useful\PatternMatcher;
 use Widmogrod\Useful\PatternNotMatchedError;
-use function Widmogrod\Useful\match;
+use function Widmogrod\Useful\matchPatterns;
 use const Widmogrod\Functional\identity;
 use const Widmogrod\Useful\any;
 
@@ -23,7 +23,7 @@ class MatchTest extends \PHPUnit\Framework\TestCase
         $this->expectException(PatternNotMatchedError::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        match($patterns, $value);
+        matchPatterns($patterns, $value);
     }
 
     public function provideInvalidPatterns()
@@ -61,7 +61,7 @@ class MatchTest extends \PHPUnit\Framework\TestCase
         $value,
         $expected
     ) {
-        $result = match($patterns, $value);
+        $result = matchPatterns($patterns, $value);
         $this->assertSame(
             $expected,
             $result


### PR DESCRIPTION
In PHP8 `match` is a reserved [keyword](https://wiki.php.net/rfc/match_expression_v2)