### PR TITLE
fix: list & iterator return declarations

### DIFF
--- a/src/Primitive/ListtCons.php
+++ b/src/Primitive/ListtCons.php
@@ -35,7 +35,7 @@ class ListtCons implements Listt, \IteratorAggregate
     /**
      * @inheritdoc
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         $tail = $this;
         do {

--- a/src/Primitive/ListtNil.php
+++ b/src/Primitive/ListtNil.php
@@ -127,7 +127,7 @@ class ListtNil implements Listt, \IteratorAggregate
     /**
      * @inheritdoc
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayObject();
     }

--- a/src/Useful/SnapshotIterator.php
+++ b/src/Useful/SnapshotIterator.php
@@ -10,7 +10,7 @@ class SnapshotIterator extends \IteratorIterator
     private $inMemoryCurrent;
     private $inSnapshot;
 
-    public function valid()
+    public function valid(): bool
     {
         if (null === $this->inMemoryValid) {
             $this->inMemoryValid = parent::valid();
@@ -19,7 +19,7 @@ class SnapshotIterator extends \IteratorIterator
         return $this->inMemoryValid;
     }
 
-    public function current()
+    public function current(): mixed
     {
         if (null === $this->inMemoryCurrent) {
             $this->inMemoryCurrent = parent::current();


### PR DESCRIPTION
Removes deprecation warning in PHP 8.1